### PR TITLE
Add WIP Nix command line support

### DIFF
--- a/demo-nix.sh
+++ b/demo-nix.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# Script for creating CLI demo
+
+# Include the demoing code
+. demo-magic.sh
+clear
+
+# Set some options
+DEMO_PROMPT=$BLUE"$ "
+DEMO_CMD_COLOR=$GREEN
+
+# Run the demo!
+
+p "# First we'll change into one of the example projects"
+pe "cd tests/fixtures/multi-lang-for-nix"
+
+p "# And take a look at the files in it"
+pe "ls"
+sleep 1
+
+p "# The 'script.R' file has one dependency"
+pe "cat script.R"
+sleep 1
+
+p "# The 'script.py' file has two dependencies"
+pe "cat script.py"
+sleep 1
+
+p "# The 'script.js' file has Dat as a dependency"
+pe "cat script.js"
+sleep 1
+
+p "# Let's start by compiling this project with Nix support"
+pe "dockter compile --nix"
+sleep 1
+
+p "# You'll see that Dockter has created several new files, prefixed with a dot"
+pe "ls -a"
+sleep 2
+
+p "# .DESCRIPTION is a R package description file, based on the packages used in script.R"
+pe "cat .DESCRIPTION"
+sleep 3
+
+p "# .environ.jsonld is a JSON-LD file which describes the project, and it's dependendies, as linked data"
+pe "cat .environ.jsonld | head -n 30"
+sleep 3
+
+p "# The .Dockerfile is generated from this information..."
+pe "cat .Dockerfile"
+sleep 3
+
+p "# The .default.nix is also generated from this information, but looks more simple than the Dockerfile"
+pe "cat .default.nix"
+sleep 3
+
+p "# The .nixDockerfile is based on NixOS rather than Ubuntu, and relies on the .default.nix file"
+pe "cat .nixDockerfile"
+sleep 3
+
+p "# Okay, so let's build this thing!"
+pe "dockter build \$PWD --nix"
+sleep 3
+
+p "# Let's check that it's built by listing the Docker images on this machine"
+pe "docker images | head -n 5"
+p "# Note that the image multi-lang-for-nix was just created"
+sleep 2
+
+p "# Now we can execute this project environment in a container running nix-shell"
+p "# This is going to take a while the first time since all dependencies need to be fetched (by Nix inside Docker)"
+pe "dockter execute \$PWD --nix"
+sleep 2
+
+# Inside the container we can demo thar Dat, R, Python, are installed in Nix hashed folders
+# and explain why this is important
+# > which python
+# > which R
+# > which dat
+# And their dependencies
+# > python -c 'import numpy ; print(numpy.version.version)'
+# > Rscript -e 'packageVersion("babynames")'
+# and then exit
+
+p "# All the packages fetched by Nix got installed inside a reusable Docker volume"
+pe "docker volume list"
+sleep 2
+
+p "# If we execute this project again, it should be much faster to launch"
+pe "dockter execute \$PWD --nix"
+sleep 2
+
+p "# Now let's switch to another project that only relies on Python"
+pe "cd ../py-for-nix"
+sleep 1
+
+p "# Let's compile this new project"
+pe "dockter compile --nix"
+sleep 2
+
+p "# We can see that .default.nix has less dependencies"
+pe "cat .default.nix"
+sleep 2
+
+p "# Let's build it!"
+pe "dockter build \$PWD --nix"
+sleep 2
+
+p "# Now, let's check our docker images again and see that we have a new image"
+pe "docker images | head -n 5"
+sleep 2
+
+p "# Let's execute it! This should be fast since we already got Python in the shared Nix store"
+pe "dockter execute \$PWD --nix"
+sleep 2
+
+# Show that Python is installed but not Dat or R
+# > which python
+# > which R
+
+p "# Check out the docs for more things you can do with Dockter. Thanks for watching!"
+sleep 2
+
+exit

--- a/src/NixGenerator.ts
+++ b/src/NixGenerator.ts
@@ -1,4 +1,3 @@
-import path from 'path'
 import Doer from './Doer'
 
 const VERSION = require('../package').version
@@ -13,7 +12,9 @@ export default class NixGenerator extends Doer {
    *
    * @param environ `SoftwareEnvironment` instance
    */
-  generate (environ: any): string {
+  generate (environ: any, folder: string): string {
+    this.folder = folder
+
     let comments = true
 
     let nixfile = ''

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
 import os from 'os'
+import fs from 'fs'
+import path from 'path'
+import { spawnSync } from 'child_process'
 // @ts-ignore
 import yargonaut from 'yargonaut'
 import yargs from 'yargs'
@@ -8,11 +11,15 @@ import yaml from 'js-yaml'
 
 const VERSION = require('../package').version
 
+import Docker from 'dockerode'
 import DockerCompiler from './DockerCompiler'
+import NixGenerator from './NixGenerator'
 import { ApplicationError } from './errors'
 import CachingUrlFetcher from './CachingUrlFetcher'
 
 const compiler = new DockerCompiler(new CachingUrlFetcher())
+const generator = new NixGenerator(new CachingUrlFetcher(), undefined)
+const docker = new Docker()
 
 yargonaut
   .style('blue')
@@ -48,7 +55,27 @@ yargs
       describe: 'The path to the project folder'
     })
   }, async (args: any) => {
-    await compiler.compile('file://' + args.folder, false).catch(error)
+    let environ = await compiler.compile('file://' + path.resolve(args.folder), false).catch(error)
+    if (args.nix) {
+      // Generate .default.nix file
+      generator.generate(environ, args.folder)
+
+      // Figure out if a custom default.nix file is present
+      let defaultNix = path.join(args.folder, 'default.nix')
+      let dockterNix = path.join(args.folder, '.default.nix')
+      let nixfile = fs.existsSync(defaultNix) ? defaultNix : dockterNix
+
+      // Generate .nixDockerfile
+      let dockerfile = path.join(args.folder, '.nixDockerfile')
+
+      fs.writeFileSync(dockerfile, `FROM nixos/nix
+
+# Copy over the Nix derivation
+COPY ${path.basename(nixfile)} default.nix
+# Run nix-shell
+CMD nix-shell --pure`
+      )
+    }
   })
 
   // Build command
@@ -60,7 +87,28 @@ yargs
       describe: 'The path to the project folder'
     })
   }, async (args: any) => {
-    await compiler.compile('file://' + args.folder, true).catch(error)
+    if (args.nix) {
+      let name = path.basename(args.folder).toLocaleLowerCase().replace(' ', '-')
+
+      // Figure out if a custom default.nix file is present
+      let defaultNix = path.join(args.folder, 'default.nix')
+      let dockterNix = path.join(args.folder, '.default.nix')
+      let nixfile = fs.existsSync(defaultNix) ? defaultNix : dockterNix
+
+      // Start building the image
+      let build = await docker.buildImage({
+        context: args.folder,
+        src: ['.nixDockerfile', path.basename(nixfile)]
+      }, { t: name, dockerfile: '.nixDockerfile' })
+
+      // Wait for image to finish building
+      docker.modem.followProgress(build, (err: any, res: any) => {
+        if (err) throw err
+        output(res)
+      })
+    } else {
+      await compiler.compile('file://' + args.folder, true).catch(error)
+    }
   })
 
   // Execute command
@@ -72,8 +120,31 @@ yargs
       describe: 'The path to the project folder'
     })
   }, async (args: any) => {
-    const node = await compiler.execute('file://' + args.folder).catch(error)
-    output(node, args.format)
+    if (args.nix) {
+      // Create shared /nix/store Docker volume if needed
+      let volumes: any = await docker.listVolumes()
+      let nixStoreVolume = volumes.Volumes.find((vol: any) => (vol.Name === 'nix-store'))
+      if (!nixStoreVolume) { await docker.createVolume({ name: 'nix-store' }) }
+
+      let name = path.basename(args.folder).toLocaleLowerCase().replace(' ', '-')
+      spawnSync(
+        'docker', `run -it --rm -v nix-store:/nix ${name} /root/.nix-profile/bin/nix-shell`.split(' '),
+        {
+          shell: true,
+          cwd: process.cwd(),
+          stdio: 'inherit'
+        }
+      )
+    } else {
+      const node = await compiler.execute('file://' + args.folder).catch(error)
+      output(node, args.format)
+    }
+  })
+
+  .option('n', {
+    alias: 'nix',
+    default: false,
+    describe: 'Enable Nix support'
   })
 
   .parse()

--- a/tests/NixGenerator.test.ts
+++ b/tests/NixGenerator.test.ts
@@ -19,8 +19,8 @@ test('generate:packages', async () => {
   const compiler = new DockerCompiler(urlFetcher)
   let environ = await compiler.compile('file://' + fixture('multi-lang-for-nix'), false, false)
 
-  const generator = new NixGenerator(urlFetcher, fixture('multi-lang-for-nix'))
-  let nixfile = generator.generate(environ).split('\n').slice(1).join('\n')
+  const generator = new NixGenerator(urlFetcher, undefined)
+  let nixfile = generator.generate(environ, fixture('multi-lang-for-nix')).split('\n').slice(1).join('\n')
 
   expect(nixfile).toEqual(expectedNixfile)
 })

--- a/tests/fixtures/py-for-nix/README.md
+++ b/tests/fixtures/py-for-nix/README.md
@@ -1,0 +1,2 @@
+A test fixture using multiple languages.
+We'll add other `script.*` files for other languages as they are supported.

--- a/tests/fixtures/py-for-nix/script.py
+++ b/tests/fixtures/py-for-nix/script.py
@@ -1,0 +1,2 @@
+import numpy
+import Pillow


### PR DESCRIPTION
* `dockter compile --nix` Adds extra `.default.nix` and `.nixDockerfile`
* `dockter build $PWD --nix` Creates project docker image, and `nix-store` docker volume (if needed)
* `dockter execute $PWD --nix` Runs `nix-shell` inside a docker container from the project docker image with reusable `/nix` mounted from the `nix-store` docker volume
